### PR TITLE
fix: adjusting and fix link generate process of twitter share #42

### DIFF
--- a/front/plugins/utils.js
+++ b/front/plugins/utils.js
@@ -1,8 +1,16 @@
 const defaultTwitterShareTitle = 'NeosVR Photo';
 
-const getIsDefaultTitle = (title) => {
-  const regex = /^\d{4}\/\d{1,2}\/\d{1,2}$/;
-  return RegExp(regex).test(title);
+const isOverTextWidth = (text, maxWidth = 500) => {
+  if (!text || maxWidth <= 0) return false;
+  try {
+    const ctx = document.createElement('canvas').getContext('2d');
+    ctx.font = '20px "Segoe UI", Meiryo, system-ui';
+    const { width } = ctx.measureText(text);
+    return width >= maxWidth;
+  } catch {
+    // empty
+  }
+  return true;
 }
 
 const openTwitterShare = (params) => {
@@ -12,27 +20,26 @@ const openTwitterShare = (params) => {
     return;
   }
   let shareTitle, shareLink;
-  const isDefaultTitle = getIsDefaultTitle(title);
   switch(type) {
     case 'modal':
-      shareTitle = isDefaultTitle ?
-        `${title} Uploaded by ${name}`
-        : title || `Uploaded by ${name}`;
+      shareTitle = isOverTextWidth(title+name) ?
+        title || `Uploaded by ${name}`
+        :`${title} Uploaded by ${name}`;
       shareLink = pageUrl || `https://photo.neos.love/?modal=${id}`;
       break;
     case 'moment':
     default:
       shareTitle = title ?
-        `${name}'s Moment - ${title}`
+        `${title} ${name}'s Moment`
         : `${name}'s Moment`;
       shareLink = pageUrl || `https://photo.neos.love/moment/${id}`;
   }
   if (!title && !name) {
     shareTitle = defaultTwitterShareTitle;
   }
-  const url = 'https://twitter.com/share'
-            + `?text=${encodeURI(shareTitle+'\n')}`
-            + `&url=${shareLink}`
+  const url = 'https://twitter.com/intent/tweet'
+            + `?text=${encodeURIComponent(shareTitle)}`
+            + `&url=${encodeURI(shareLink)}`
             + '&hashtags=NeosFrames';
   try {
     window.open(url, '_blank');


### PR DESCRIPTION
## Descipton
ツイッター共有URLの生成処理まわりを色々と手直しします

## Changes
- #42 を修正
- 投稿タイトルにHTMLタグ等が含まれていると死ぬ問題を修正
- Moment の投稿タイトルで投稿者名が後ろに来るよう変更
- Modal の投稿タイトルの調節ロジックを表示幅基準に変更
